### PR TITLE
0.3.0: refactor chunked encryption

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "*" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,6 +19,6 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Lint (clippy)
-      run: cargo clippy
+      run: cargo clippy -- -D warnings
     - name: Run tests
       run: cargo test --verbose

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,5 +18,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build
       run: cargo build --verbose
+    - name: Lint (clippy)
+      run: cargo clippy
     - name: Run tests
       run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ description = "Symmetric and asymmetric encryption for DRACOON in Rust."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+log = "0.4.17"
 serde_json = "1.0.89"
 serde = { version = "1.0.149", features = ["serde_derive"] }
 openssl = { version = "0.10", features = ["vendored"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "dco3_crypto"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Octavio Simone"]
 repository = "https://github.com/unbekanntes-pferd/dco3-crypto"
 homepage = "https://github.com/unbekanntes-pferd/dco3-crypto"
 license = "MIT"
 readme = "README.md"
-license-file = "LICENSE"
 keywords = ["dracoon", "cryptography", "openssl"]
 description = "Symmetric and asymmetric encryption for DRACOON in Rust."
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <p align="center">
     DRACOON Crypto utils in Rust
     <br />
-    <a href="https://github.com/unbekanntes-pferd/dco3-crypto"><strong>Explore the docs »</strong></a>
+    <a href="https://docs.rs/dco3_crypto/latest/dco3_crypto"><strong>Documentation »</strong></a>
     <br />
     <a href="https://github.com/unbekanntes-pferd/dco3-crypto/issues">Report Bug</a>
   </p>
@@ -15,9 +15,14 @@
 
 Work in progress Crypto library for DRACOON based on openssl crate.
 
+**Breaking changes** are most likely at this early stage - the library is under heavy development and depends on requirements from `dco3` (currently private API wrapper for DRACOON).
+Changes will be documented in the [release notes](https://github.com/unbekanntes-pferd/dco3-crypto/releases).
+
 ### What does work?
 
 - Asymmetric encryption / decryption of file keys (RSA)
+- Keypair generation (RSA)
+- Keypair encryption / decryption (RSA)
 - Symmetric encryption / decryption of messages (AES256 GCM)
   - on the fly encryption / decryption 
   - chunked encryption / decryption
@@ -25,24 +30,25 @@ Work in progress Crypto library for DRACOON based on openssl crate.
 ### What is planned?
 
 - Refactor asymmetric encryption (split keypair generation from other operations)
-- Use other libraries like ring as alternative to openssl bindings 
+- Use other libraries like ring as alternative to openssl bindings
+- Add feature flags to cargo build
 - Add e2e tests using encryption data from other SDKs / libs and ensure compatibility in pipeline
 
 ### What is shipped?
-Using the crate binds to the latest openssl version and is compiled in vendored mode (see [openssl](https://crates.io/crates/openssl) for details). 
+Using the crate currently binds to the latest openssl version and is compiled in vendored mode (see [openssl](https://crates.io/crates/openssl) for details). 
 
 ### How to use?
 
 See [crates.io](https://crates.io/crates/dco3_crypto)
 TL;DR Add the following line to your Cargo.toml file (dependencies):
 ```toml
-dco3_crypto = "0.2.0"
+dco3_crypto = "0.3.0"
 ```
 
 ## Documentation
 
 [Documentation](https://docs.rs/dco3_crypto/latest/dco3_crypto)
-All documentation is provided via docs on [docs.rs](https://docs.rs/dco3_crypto/latest/dco3_crypto)
+All detailed documentation is provided via docs on [docs.rs](https://docs.rs/dco3_crypto/latest/dco3_crypto)
 
 ## TL; DR usage
 
@@ -59,11 +65,6 @@ In order to
 - encrypt a file key with a public key (user keypair)
 - decrypt a file key with a private key (user keypair)
 
-import `DracoonCrypto` and `DracoonRSACrypto`:
-
-```rust
-use dco3_crypto::{DracoonCrypto, DracoonRSACrypto};
-```
 
 Generate a plain user keypair:
 
@@ -197,7 +198,7 @@ use openssl::symm::Cipher;
 let message = b"Encrypt this very long message in chunks and decrypt it";
     
 let (message, plain_file_key) = DracoonCrypto::encrypt(message.to_vec()).unwrap();
-let buff_len = message.len() + Cipher::aes_256_gcm().block_size();
+let buff_len = message.len() + 1;
     
 let mut chunks = message.chunks(5);
 let mut buf = vec![0u8; buff_len];

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ Work in progress Crypto library for DRACOON based on openssl crate.
 
 ### What is planned?
 
-- Chunked encryption / decryption is currently not generic and requires openssl crate
-  - make Crypter generic, so that other libraries can be used
+- Refactor asymmetric encryption (split keypair generation from other operations)
+- Use other libraries like ring as alternative to openssl bindings 
+- Add e2e tests using encryption data from other SDKs / libs and ensure compatibility in pipeline
 
 ### What is shipped?
 Using the crate binds to the latest openssl version and is compiled in vendored mode (see [openssl](https://crates.io/crates/openssl) for details). 
@@ -42,3 +43,172 @@ dco3_crypto = "0.2.0"
 
 [Documentation](https://docs.rs/dco3_crypto/latest/dco3_crypto)
 All documentation is provided via docs on [docs.rs](https://docs.rs/dco3_crypto/latest/dco3_crypto)
+
+## TL; DR usage
+
+### Required imports
+
+The lib consists of several traits that are all (currently only) implemented by the `DracoonCrypto` struct.
+Therefore, the minimum required import is *always* `DracoonCrypto` and the relevant required trait (`DracoonRSACrypto`, `Encrypt`, `Decrypt`, `ChunkedEncryption`, `Encrypter`, `Decrypter`).
+
+#### Asymmetric encryption
+
+In order to 
+- generate a (plain) user keypair 
+- en/decrypt a user keypair
+- encrypt a file key with a public key (user keypair)
+- decrypt a file key with a private key (user keypair)
+
+import `DracoonCrypto` and `DracoonRSACrypto`:
+
+```rust
+use dco3_crypto::{DracoonCrypto, DracoonRSACrypto};
+```
+
+Generate a plain user keypair:
+
+```rust
+use dco3_crypto::{DracoonCrypto, DracoonRSACrypto, UserKeypairVersion};
+
+// RSA2048 is only supported for legacy compatibility 
+// always use UserKeypairVersion::RSA4096
+let new_keypair = DracoonCrypto::create_plain_user_keypair(UserKeyPairVersion::RSA4096).unwrap();
+
+```
+
+Encrypt a plain user keypair:
+
+```rust
+use dco3_crypto::{DracoonCrypto, DracoonRSACrypto, UserKeypairVersion};
+
+let new_keypair = DracoonCrypto::create_plain_user_keypair(UserKeyPairVersion::RSA4096).unwrap();
+let secret ="VerySecret123!";
+let enc_keypair = DracoonCrypto::encrypt_private_key(secret, new_keypair).unwrap();
+
+```
+
+Decrypt a protected user keypair:
+```rust
+use dco3_crypto::{DracoonCrypto, DracoonRSACrypto, UserKeypairVersion};
+
+let new_keypair = DracoonCrypto::create_plain_user_keypair(UserKeyPairVersion::RSA4096).unwrap();
+let secret ="VerySecret123!";
+let enc_keypair = DracoonCrypto::encrypt_private_key(secret, new_keypair).unwrap();
+let plain_keypair = DracoonCrypto::decrypt_private_key(secret, enc_keypair).unwrap();
+
+```
+
+Encrypt a file key using either a plain user keypair or a public key container:
+
+```rust
+use dco3_crypto::{DracoonCrypto, DracoonRSACrypto, UserKeypairVersion, Encrypt};
+let new_keypair = DracoonCrypto::create_plain_user_keypair(UserKeyPairVersion::RSA4096).unwrap();
+
+// encrypt a message to get a plain file key for demo purposes
+let message = b"Secret message";
+let (enc_message, plain_file_key) = DracoonCrypto::encrypt(message.to_vec()).unwrap();
+
+// the function also accepts a public key container as argument
+let enc_file_key = DracoonCrypto::encrypt_file_key(plain_file_key, plain_keypair).unwrap();
+```
+
+Decrypt the file key using a plain user keypair:
+```rust
+use dco3_crypto::{DracoonCrypto, DracoonRSACrypto, UserKeypairVersion, Encrypt};
+let new_keypair = DracoonCrypto::create_plain_user_keypair(UserKeyPairVersion::RSA4096).unwrap();
+
+// encrypt a message to get a plain file key for demo purposes
+let message = b"Secret message";
+let (enc_message, plain_file_key) = DracoonCrypto::encrypt(message.to_vec()).unwrap();
+
+// the function also accepts a public key container as argument
+let enc_file_key = DracoonCrypto::encrypt_file_key(plain_file_key, plain_keypair).unwrap();
+
+// this code is for demo purposes - plain_keypair is consumed above and needs to be 
+// instantiated again
+let plain_file_key = DracoonCrypto::decrypt_file_key(enc_file_key, plain_keypair).unwrap();
+```
+
+#### Symmetric encryption
+
+Symmetric encryption is represented by the following traits:
+
+- Encrypt: needed for in-memory encryption
+- Decrypt: needed for in-memory decryption
+- Decrypter: needed to build a decrypter capable of chunked decryption
+- Encrypter: needed to build an encrypter capable of chunked encryption
+- ChunkedEncryption: needed for both en- and decryption when using a decrypter / encrypter
+
+Encrypt a message on the fly:
+
+```rust
+use dco3_crypto::{DracoonCrypto, Encrypt};
+
+// encrypt a message to get a plain file key for demo purposes
+let message = b"Secret message";
+let (enc_message, plain_file_key) = DracoonCrypto::encrypt(message.to_vec()).unwrap();
+
+// to encrypt the file key, see asymmetric encryption above
+```
+
+Decrypt a message on the fly:
+
+```rust
+use dco3_crypto::{DracoonCrypto, Encrypt, Decrypt};
+
+// encrypt a message to get a plain file key for demo purposes
+let message = b"Secret message";
+let (enc_message, plain_file_key) = DracoonCrypto::encrypt(message.to_vec()).unwrap();
+
+// to decrypt / encrypt the file key, see asymmetric encryption above
+let plain_message = DracoonCrypto::decrypt(&enc_message, plain_file_key);
+```
+
+Encrypt in chunks:
+
+```rust
+use dco3_crypto::{DracoonCrypto, Encrypter, ChunkedEncryption};
+let mut message = b"Encrypt this very long message in chunks and decrypt it";
+let buff_len = message.len() + 1;
+let mut buf = vec![0u8; buff_len];
+let mut encrypter = DracoonCrypto::encrypter(&mut buf).unwrap();
+let mut count: usize = 0;
+
+// chunks of 8 bytes
+const CHUNKSIZE: usize = 8;
+let mut chunks = message.chunks(CHUNKSIZE);
+while let Some(chunk) = chunks.next() {
+  count += encrypter.update(&chunk).unwrap();
+  };
+
+count += encrypter.finalize().unwrap();
+let enc_message = encrypter.get_message();
+let plain_file_key = encrypter.get_plain_file_key();
+
+```
+
+
+Decrypt in chunks:
+
+```rust
+// importing Encrypt is only necessary for the inital message encryption
+use dco3_crypto::{DracoonCrypto, Encrypt, Decrypter, ChunkedEncryption};
+use openssl::symm::Cipher;
+let message = b"Encrypt this very long message in chunks and decrypt it";
+    
+let (message, plain_file_key) = DracoonCrypto::encrypt(message.to_vec()).unwrap();
+let buff_len = message.len() + Cipher::aes_256_gcm().block_size();
+    
+let mut chunks = message.chunks(5);
+let mut buf = vec![0u8; buff_len];
+let mut decrypter = DracoonCrypto::decrypter(plain_file_key, &mut buf).unwrap();
+let mut count: usize = 0;
+while let Some(chunk) = chunks.next() {
+  count += decrypter.update(&chunk).unwrap();
+  }
+
+count += decrypter.finalize().unwrap();
+    
+let plain_message = std::str::from_utf8(decrypter.get_message()).unwrap();
+  
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,12 @@
 //! `dco3-crypto` is a wrapper around symmetric and asymmetric encryption used in DRACOON.
 //! DRACOON is a cloud service provider - more information can be found on https://dracoon.com
 //! Files are encrypted with AES 256 GCM using random bytes as individual key for each file.
-//! Users have a symmetric RSA keypair (4096bit) and use the public key to encrypt the file keys for 
+//! Users have a symmetric RSA keypair (4096bit) and use the public key to encrypt the file keys for
 //! file en- and decryption. The private key is used to decrypt file keys.
-//! 
+//!
 //! The crate is based on openssl, which allows to generate keypairs and to perform desired en- and decryption
 //! operations.
-//! 
+//!
 
 //use models::*;
 use openssl::base64;
@@ -27,11 +27,11 @@ pub use models::*;
 /// - [DracoonRSACrypto]
 /// - [Encrypt]
 /// - [Decrypt]
-/// 
+///
 pub struct DracoonCrypto;
 
 impl DracoonRSACrypto for DracoonCrypto {
-    /// Creates a plain RSA keypair required for DRACOON to encrypt 
+    /// Creates a plain RSA keypair required for DRACOON to encrypt
     /// and decrypt file keys.
     /// Using a 4096 bit keypair is recommended - 2048 bit is for legacy support and usage
     /// is discouraged.
@@ -41,7 +41,7 @@ impl DracoonRSACrypto for DracoonCrypto {
     /// let plain_4096_keypair =
     /// DracoonCrypto::create_plain_user_keypair(UserKeyPairVersion::RSA4096).unwrap();
     /// ```
-    /// 
+    ///
     fn create_plain_user_keypair(
         version: UserKeyPairVersion,
     ) -> Result<PlainUserKeyPairContainer, DracoonCryptoError> {
@@ -68,7 +68,7 @@ impl DracoonRSACrypto for DracoonCrypto {
             version,
         ))
     }
-    /// Encrypts a plain keypair container - specifically the private key - using 
+    /// Encrypts a plain keypair container - specifically the private key - using
     /// a secret provided as parameter.
     /// # Example
     /// ```
@@ -78,7 +78,7 @@ impl DracoonRSACrypto for DracoonCrypto {
     /// DracoonCrypto::create_plain_user_keypair(UserKeyPairVersion::RSA4096).unwrap();
     /// let enc_4096_keypair = DracoonCrypto::encrypt_private_key(secret, plain_4096_keypair).unwrap();
     /// ```
-    /// 
+    ///
     fn encrypt_private_key(
         secret: &str,
         plain_keypair: PlainUserKeyPairContainer,
@@ -86,11 +86,11 @@ impl DracoonRSACrypto for DracoonCrypto {
         let secret = secret.as_bytes();
         let private_key_pem = plain_keypair.private_key_container.private_key.as_bytes();
 
-        let rsa = Rsa::private_key_from_pem(&private_key_pem)?;
+        let rsa = Rsa::private_key_from_pem(private_key_pem)?;
         let rsa = PKey::from_rsa(rsa)?;
 
         let private_key_pem =
-            rsa.private_key_to_pem_pkcs8_passphrase(Cipher::aes_256_cbc(), &secret)?;
+            rsa.private_key_to_pem_pkcs8_passphrase(Cipher::aes_256_cbc(), secret)?;
         let private_key_pem = std::str::from_utf8(&private_key_pem)?;
 
         Ok(UserKeyPairContainer::new_from_plain_keypair(
@@ -98,7 +98,7 @@ impl DracoonRSACrypto for DracoonCrypto {
             private_key_pem,
         ))
     }
-    /// Decrypts an encrypted keypair container - specifically the private key - using 
+    /// Decrypts an encrypted keypair container - specifically the private key - using
     /// a secret provided as parameter.
     /// # Example
     /// ```
@@ -107,10 +107,10 @@ impl DracoonRSACrypto for DracoonCrypto {
     /// let plain_4096_keypair =
     /// DracoonCrypto::create_plain_user_keypair(UserKeyPairVersion::RSA4096).unwrap();
     /// let enc_4096_keypair = DracoonCrypto::encrypt_private_key(secret, plain_4096_keypair).unwrap();
-    /// 
+    ///
     /// let plain_keypair = DracoonCrypto::decrypt_private_key(secret, enc_4096_keypair).unwrap();
     /// ```
-    /// 
+    ///
     fn decrypt_private_key(
         secret: &str,
         keypair: UserKeyPairContainer,
@@ -118,7 +118,7 @@ impl DracoonRSACrypto for DracoonCrypto {
         let secret = secret.as_bytes();
         let private_key_pem = keypair.private_key_container.private_key.as_bytes();
 
-        let rsa = PKey::private_key_from_pem_passphrase(&private_key_pem, &secret)?;
+        let rsa = PKey::private_key_from_pem_passphrase(private_key_pem, secret)?;
         let rsa = rsa.rsa()?;
         let private_key_pem = rsa
             .private_key_to_pem()
@@ -131,32 +131,35 @@ impl DracoonRSACrypto for DracoonCrypto {
             &private_key_pem,
         ))
     }
-    /// Encrypts a file key used for file encryption using either the public key or a plain keypair 
+    /// Encrypts a file key used for file encryption using either the public key or a plain keypair
     /// container.
     /// # Example
     /// ```
     /// use dco3_crypto::{DracoonCrypto, DracoonRSACrypto, PlainFileKey, UserKeyPairVersion};
-    /// 
+    ///
     /// let plain_4096_keypair =
     /// DracoonCrypto::create_plain_user_keypair(UserKeyPairVersion::RSA4096).unwrap();
-    /// 
+    ///
     /// let plain_file_key = PlainFileKey::try_new_for_encryption().unwrap();
     /// let enc_file_key = DracoonCrypto::encrypt_file_key(plain_file_key, plain_4096_keypair).unwrap();
-    /// 
-    /// 
+    ///
+    ///
     /// ```
-    /// 
+    ///
     fn encrypt_file_key(
         plain_file_key: PlainFileKey,
         public_key: impl PublicKey,
     ) -> Result<FileKey, DracoonCryptoError> {
         let public_key_pem = public_key.get_public_key().public_key.as_bytes();
-        let rsa = Rsa::public_key_from_pem(public_key_pem)?;
+        let rsa = Rsa::public_key_from_pem(public_key_pem)
+            .map_err(|_| DracoonCryptoError::RsaImportFailed)?;
 
-        let pkey = PKey::from_rsa(rsa)?;
+        let pkey = PKey::from_rsa(rsa).map_err(|_| DracoonCryptoError::RsaImportFailed)?;
 
         let file_key = &plain_file_key.key;
-        let file_key = base64::decode_block(file_key)?;
+        let file_key = base64::decode_block(file_key).map_err(|_| {
+            DracoonCryptoError::InvalidFileKeyFormat("Cannot parse key.".to_string())
+        })?;
 
         let file_key_version: FileKeyVersion = match public_key.get_public_key().version {
             UserKeyPairVersion::RSA2048 => FileKeyVersion::RSA2048_AES256GCM,
@@ -173,8 +176,8 @@ impl DracoonRSACrypto for DracoonCrypto {
 
         key_ctx.encrypt_init()?;
         key_ctx.set_rsa_padding(Padding::PKCS1_OAEP)?;
-        key_ctx.set_rsa_oaep_md(&md)?;
-        key_ctx.set_rsa_mgf1_md(&mgf1_md)?;
+        key_ctx.set_rsa_oaep_md(md)?;
+        key_ctx.set_rsa_mgf1_md(mgf1_md)?;
 
         let mut buf: Vec<u8> = Vec::new();
         key_ctx.encrypt_to_vec(&file_key, &mut buf)?;
@@ -188,12 +191,12 @@ impl DracoonRSACrypto for DracoonCrypto {
         ))
     }
 
-    /// Decrypts a file key used for file encryption using a plain keypair 
+    /// Decrypts a file key used for file encryption using a plain keypair
     /// container.
     /// # Example
     /// ```
     /// use dco3_crypto::{DracoonCrypto, DracoonRSACrypto, PlainFileKey, UserKeyPairVersion, PublicKeyContainer};
-    /// 
+    ///
     /// let plain_4096_keypair =
     /// DracoonCrypto::create_plain_user_keypair(UserKeyPairVersion::RSA4096).unwrap();
     /// let public_key_container = PublicKeyContainer {
@@ -207,19 +210,22 @@ impl DracoonRSACrypto for DracoonCrypto {
     /// let enc_file_key = DracoonCrypto::encrypt_file_key(plain_file_key, public_key_container).unwrap();
 
     /// let plain_file_key = DracoonCrypto::decrypt_file_key(enc_file_key, plain_4096_keypair).unwrap();
-    /// 
+    ///
     /// ```
-    /// 
+    ///
     fn decrypt_file_key(
         file_key: FileKey,
         keypair: PlainUserKeyPairContainer,
     ) -> Result<PlainFileKey, DracoonCryptoError> {
         let private_key_pem = keypair.private_key_container.private_key.as_bytes();
-        let rsa = Rsa::private_key_from_pem(private_key_pem)?;
+        let rsa = Rsa::private_key_from_pem(private_key_pem)
+            .map_err(|_| DracoonCryptoError::RsaImportFailed)?;
 
-        let pkey = PKey::from_rsa(rsa)?;
+        let pkey = PKey::from_rsa(rsa).map_err(|_| DracoonCryptoError::RsaImportFailed)?;
 
-        let enc_file_key = base64::decode_block(&file_key.key)?;
+        let enc_file_key = base64::decode_block(&file_key.key).map_err(|_| {
+            DracoonCryptoError::InvalidFileKeyFormat("Cannot parse key.".to_string())
+        })?;
 
         let mut key_ctx = PkeyCtx::new(&pkey)?;
         let mgf1_md = Md::sha256();
@@ -231,8 +237,8 @@ impl DracoonRSACrypto for DracoonCrypto {
 
         key_ctx.decrypt_init()?;
         key_ctx.set_rsa_padding(Padding::PKCS1_OAEP)?;
-        key_ctx.set_rsa_oaep_md(&md)?;
-        key_ctx.set_rsa_mgf1_md(&mgf1_md)?;
+        key_ctx.set_rsa_oaep_md(md)?;
+        key_ctx.set_rsa_mgf1_md(mgf1_md)?;
 
         let mut buf: Vec<u8> = Vec::new();
         key_ctx.decrypt_to_vec(&enc_file_key, &mut buf)?;
@@ -245,29 +251,34 @@ impl DracoonRSACrypto for DracoonCrypto {
 
 /// Implements encryption based on AES256 GCM.
 /// Provides function to encrypt on the fly and another one to create a Crypter in order
-/// to encrypt in chunks. 
+/// to encrypt in chunks.
 impl Encrypt<OpenSslCrypter> for DracoonCrypto {
     /// Encrypts bytes on the fly - full message is expected and passed as data.
-    /// 
+    ///
     /// # Example
     /// ```
     /// use dco3_crypto::{DracoonCrypto, Encrypt};
     /// let message = b"Encrypt me please";
     /// let enc_message = DracoonCrypto::encrypt(message.to_vec()).unwrap();
-    /// 
+    ///
     /// ```
     fn encrypt(data: Vec<u8>) -> Result<EncryptionResult, DracoonCryptoError> {
         let cipher = Cipher::aes_256_gcm();
 
         let mut plain_file_key = PlainFileKey::try_new_for_encryption()?;
 
-        let key = base64::decode_block(&plain_file_key.key)?;
-        let iv = base64::decode_block(&plain_file_key.iv)?;
+        let key = base64::decode_block(&plain_file_key.key).map_err(|_| {
+            DracoonCryptoError::InvalidFileKeyFormat("Cannot parse key.".to_string())
+        })?;
+        let iv = base64::decode_block(&plain_file_key.iv).map_err(|_| {
+            DracoonCryptoError::InvalidFileKeyFormat("Cannot parse iv.".to_string())
+        })?;
 
         let aad = b"";
         let mut tag = [0; 16];
 
-        let res = encrypt_aead(cipher, &key, Some(&iv), aad, &data, &mut tag)?;
+        let res = encrypt_aead(cipher, &key, Some(&iv), aad, &data, &mut tag)
+            .map_err(|_| DracoonCryptoError::BadData)?;
 
         let tag = base64::encode_block(&tag);
         plain_file_key.set_tag(tag);
@@ -275,7 +286,7 @@ impl Encrypt<OpenSslCrypter> for DracoonCrypto {
         Ok((res, plain_file_key))
     }
     /// Returns a Crypter for chunked encryption
-    /// 
+    ///
     /// Accepts a buffer to store the encrypted message to.
     /// In order to encrypt in chunks, you need to
     /// - get an encrypter and pass a buffer
@@ -283,13 +294,13 @@ impl Encrypt<OpenSslCrypter> for DracoonCrypto {
     /// - finalize the encryption once all chunks were read
     /// - get the message (as bytes) from the encrypter
     /// - get the plain file key from the encrypter
-    /// 
+    ///
     /// # Example
     /// ```
     /// use dco3_crypto::{DracoonCrypto, Encrypt, ChunkedEncryption};
     /// use openssl::symm::Cipher;
     /// use std::io::Read;
-    /// 
+    ///
     /// let message = b"Encrypt this very long message in chunks and decrypt it";
     /// let buff_len = message.len() + Cipher::aes_256_gcm().block_size();
     /// let mut chunk = [0u8; 5];
@@ -298,15 +309,15 @@ impl Encrypt<OpenSslCrypter> for DracoonCrypto {
     /// DracoonCrypto::get_encrypter(&mut buf).unwrap();
     /// let mut count: usize = 0;
     /// let mut cursor = std::io::Cursor::new(&message);
-    /// 
+    ///
     /// while cursor.read_exact(&mut chunk).is_ok() {
     /// count += encrypter.update(&chunk).unwrap();
     /// }
     /// count += encrypter.finalize().unwrap();
-    /// 
+    ///
     /// let enc_message = encrypter.get_message();
     /// let plain_file_key = encrypter.get_plain_file_key();
-    /// 
+    ///
     /// ```
     fn get_encrypter(buffer: &mut Vec<u8>) -> Result<Crypter<OpenSslCrypter>, DracoonCryptoError> {
         Crypter::try_new_for_encryption(buffer)
@@ -315,56 +326,59 @@ impl Encrypt<OpenSslCrypter> for DracoonCrypto {
 
 /// Implements decryption based on AES256 GCM.
 /// Provides function to decrypt on the fly and another one to create a Crypter in order
-/// to decrypt in chunks. 
+/// to decrypt in chunks.
 impl Decrypt<OpenSslCrypter> for DracoonCrypto {
     /// Decrypts bytes on the fly - full message is expected and passed as data.
-    /// 
+    ///
     /// # Example
     /// ```
     /// use dco3_crypto::{DracoonCrypto, Decrypt, Encrypt};
     /// let message = b"Encrypt me please";
     /// let enc_message = DracoonCrypto::encrypt(message.to_vec()).unwrap();
     /// let plain_message = DracoonCrypto::decrypt(enc_message.0, enc_message.1);
-    /// 
+    ///
     /// ```
     fn decrypt(data: Vec<u8>, plain_file_key: PlainFileKey) -> Result<Vec<u8>, DracoonCryptoError> {
         let cipher = Cipher::aes_256_gcm();
 
-        let key = base64::decode_block(&plain_file_key.key)?;
-        let iv = base64::decode_block(&plain_file_key.iv)?;
-        let tag = base64::decode_block(
-            &plain_file_key
-                .tag
-                .ok_or(DracoonCryptoError::ByteParseError)?,
-        )?;
+        let key = base64::decode_block(&plain_file_key.key).map_err(|_| {
+            DracoonCryptoError::InvalidFileKeyFormat("Cannot parse key.".to_string())
+        })?;
+        let iv = base64::decode_block(&plain_file_key.iv).map_err(|_| {
+            DracoonCryptoError::InvalidFileKeyFormat("Cannot parse iv.".to_string())
+        })?;
+        let tag = base64::decode_block(&plain_file_key.tag.ok_or_else(||
+            DracoonCryptoError::InvalidFileKeyFormat("Invalid tag.".to_string()),
+        )?)?;
 
         let aad = b"";
 
-        let res = decrypt_aead(cipher, &key, Some(&iv), aad, &data, &tag)?;
+        let res = decrypt_aead(cipher, &key, Some(&iv), aad, &data, &tag)
+            .map_err(|_| DracoonCryptoError::BadData)?;
 
         Ok(res)
     }
 
     /// Returns a Crypter for chunked decryption
-    /// 
+    ///
     /// Accepts a buffer to store the decrypted message to.
     /// In order to decrypt in chunks, you need to
     /// - get a decrypter and pass a buffer and the plain file key
     /// - update the decrypter by passing the chunks
     /// - finalize the decryption once all chunks were read
     /// - get the message (as bytes) from the encrypter
-    /// 
+    ///
     /// # Example
     /// ```
     /// use dco3_crypto::{DracoonCrypto, Encrypt, Decrypt, ChunkedEncryption};
     /// use openssl::symm::Cipher;
     /// use std::io::Read;
     /// let message = b"Encrypt this very long message in chunks and decrypt it";
-    /// 
+    ///
     /// /// returns a tuple containing the message and the plain file key
     /// let message = DracoonCrypto::encrypt(message.to_vec()).unwrap();
     /// let buff_len = message.0.len() + Cipher::aes_256_gcm().block_size();
-    /// 
+    ///
     /// /// chunks of 5
     /// let mut chunk = [0u8; 5];
     /// let mut buf = vec![0u8; buff_len];
@@ -375,10 +389,10 @@ impl Decrypt<OpenSslCrypter> for DracoonCrypto {
     ///    count += decrypter.update(&chunk).unwrap();
     ///}
     /// count += decrypter.finalize().unwrap();
-    /// 
+    ///
     /// let plain_message = std::str::from_utf8(decrypter.get_message()).unwrap();
     /// ```
-    /// 
+    ///
     fn get_decrypter(
         plain_file_key: PlainFileKey,
         buffer: &mut Vec<u8>,
@@ -387,73 +401,115 @@ impl Decrypt<OpenSslCrypter> for DracoonCrypto {
     }
 }
 
-impl <'b> ChunkedEncryption<'b, OpenSslCrypter> for  Crypter<'b, OpenSslCrypter> {
-    fn try_new_for_decryption(plain_file_key: PlainFileKey, buffer: &'b mut Vec<u8>) -> Result<Self, DracoonCryptoError> {
-       let cipher = Cipher::aes_256_gcm();
-       let key = base64::decode_block(&plain_file_key.key)?;
-       let iv = base64::decode_block(&plain_file_key.iv)?;
-       let tag = plain_file_key.tag.clone().ok_or(DracoonCryptoError::CrypterOperationFailed)?;
-       let tag = base64::decode_block(&tag)?;
+impl<'b> ChunkedEncryption<'b, OpenSslCrypter> for Crypter<'b, OpenSslCrypter> {
+    fn try_new_for_decryption(
+        plain_file_key: PlainFileKey,
+        buffer: &'b mut Vec<u8>,
+    ) -> Result<Self, DracoonCryptoError> {
+        let cipher = Cipher::aes_256_gcm();
+        let key = base64::decode_block(&plain_file_key.key).map_err(|_| {
+            DracoonCryptoError::InvalidFileKeyFormat("Cannot parse key.".to_string())
+        })?;
+        let iv = base64::decode_block(&plain_file_key.iv).map_err(|_| {
+            DracoonCryptoError::InvalidFileKeyFormat("Cannot parse iv.".to_string())
+        })?;
+        let tag = plain_file_key
+            .tag
+            .clone()
+            .ok_or_else(|| DracoonCryptoError::InvalidFileKeyFormat(
+                "Invalid tag.".to_string(),
+            ))?;
+        let tag = base64::decode_block(&tag)
+            .map_err(|_| DracoonCryptoError::InvalidFileKeyFormat("Invalid tag.".to_string()))?;
 
-       let mut crypter = OpenSslCrypter::new(cipher, Mode::Decrypt, &key, Some(&iv))?;
+        let mut crypter = OpenSslCrypter::new(cipher, Mode::Decrypt, &key, Some(&iv))
+            .map_err(|_| DracoonCryptoError::CrypterOperationFailed)?;
 
-       crypter.aad_update(b"")?;
-       crypter.set_tag(&tag)?;
+        crypter
+            .aad_update(b"")
+            .map_err(|_| DracoonCryptoError::CrypterOperationFailed)?;
+        crypter
+            .set_tag(&tag)
+            .map_err(|_| DracoonCryptoError::CrypterOperationFailed)?;
 
-       Ok(Crypter { crypter, buffer, count: 0, plain_file_key, mode: Mode::Decrypt })
-   }
+        Ok(Crypter {
+            crypter,
+            buffer,
+            count: 0,
+            plain_file_key,
+            mode: Mode::Decrypt,
+        })
+    }
 
     fn try_new_for_encryption(buffer: &'b mut Vec<u8>) -> Result<Self, DracoonCryptoError> {
-       let cipher = Cipher::aes_256_gcm();
-       let plain_file_key = PlainFileKey::try_new_for_encryption()?;
-       let key = base64::decode_block(&plain_file_key.key)?;
-       let iv = base64::decode_block(&plain_file_key.iv)?;
+        let cipher = Cipher::aes_256_gcm();
+        let plain_file_key = PlainFileKey::try_new_for_encryption()?;
+        let key = base64::decode_block(&plain_file_key.key).map_err(|_| {
+            DracoonCryptoError::InvalidFileKeyFormat("Cannot parse key.".to_string())
+        })?;
+        let iv = base64::decode_block(&plain_file_key.iv).map_err(|_| {
+            DracoonCryptoError::InvalidFileKeyFormat("Cannot parse iv.".to_string())
+        })?;
 
-       let mut crypter = OpenSslCrypter::new(cipher, Mode::Encrypt, &key, Some(&iv))?;
-       crypter.aad_update(b"")?;
+        let mut crypter = OpenSslCrypter::new(cipher, Mode::Encrypt, &key, Some(&iv))
+            .map_err(|_| DracoonCryptoError::CrypterOperationFailed)?;
+        crypter
+            .aad_update(b"")
+            .map_err(|_| DracoonCryptoError::CrypterOperationFailed)?;
 
-       Ok(Crypter { crypter, buffer, count: 0, plain_file_key, mode: Mode::Encrypt })
-   }
+        Ok(Crypter {
+            crypter,
+            buffer,
+            count: 0,
+            plain_file_key,
+            mode: Mode::Encrypt,
+        })
+    }
 
     fn update(&mut self, data: &[u8]) -> Result<usize, DracoonCryptoError> {
-
-       match self.crypter.update(data, &mut self.buffer[self.count..]) {
-           Ok(count) => {self.count += count; Ok(count)},
-           Err(_) => Err(DracoonCryptoError::CrypterOperationFailed)
-       }
-
-   }
+        match self.crypter.update(data, &mut self.buffer[self.count..]) {
+            Ok(count) => {
+                self.count += count;
+                Ok(count)
+            }
+            Err(_) => Err(DracoonCryptoError::CrypterOperationFailed),
+        }
+    }
 
     fn set_tag(&mut self, tag: &[u8]) -> Result<(), DracoonCryptoError> {
-       Ok(self.crypter.set_tag(tag)?)
-   }
+        self
+            .crypter
+            .set_tag(tag)
+            .map_err(|_| DracoonCryptoError::CrypterOperationFailed)
+    }
 
-   fn finalize(&mut self) -> Result<usize, DracoonCryptoError> {
+    fn finalize(&mut self) -> Result<usize, DracoonCryptoError> {
+        let count = self
+            .crypter
+            .finalize(&mut self.buffer[self.count..])
+            .map_err(|_| DracoonCryptoError::CrypterOperationFailed)?;
 
-       let count = self.crypter.finalize(&mut self.buffer[self.count..])?;
+        if let Mode::Encrypt = self.mode {
+            let mut buf = [0u8; 16];
+            self.crypter
+                .get_tag(&mut buf)
+                .map_err(|_| DracoonCryptoError::CrypterOperationFailed)?;
+            let tag = base64::encode_block(&buf);
+            self.plain_file_key.tag = Some(tag);
+        };
 
-       if let Mode::Encrypt = self.mode {
-           let mut buf = [0u8; 16];
-           self.crypter.get_tag(&mut buf)?; 
-           let tag = base64::encode_block(&buf);
-           self.plain_file_key.tag = Some(tag);
+        Ok(count)
+    }
 
-       };
+    fn get_message(&mut self) -> &Vec<u8> {
+        self.buffer.truncate(self.count);
 
-      Ok(count)
-   }
+        self.buffer
+    }
 
-   fn get_message(&mut self) -> &Vec<u8> {
-
-       self.buffer.truncate(self.count);
-
-       &self.buffer
-   }
-
-   fn get_plain_file_key(self) -> PlainFileKey {
-       self.plain_file_key
-   }
-
+    fn get_plain_file_key(self) -> PlainFileKey {
+        self.plain_file_key
+    }
 }
 
 #[cfg(test)]
@@ -569,8 +625,6 @@ mod tests {
             version: PlainFileKeyVersion::AES256CM,
         };
 
-    
-
         let enc_file_key = DracoonCrypto::encrypt_file_key(plain_file_key, public_key_container)
             .expect("Should not fail");
 
@@ -648,14 +702,11 @@ mod tests {
             DracoonCrypto::get_decrypter(message.1, &mut buf).expect("Should not fail");
         let mut count: usize = 0;
 
-    
         while cursor.read_exact(&mut chunk).is_ok() {
             count += decrypter.update(&chunk).expect("Should not fail");
         }
 
-        count += decrypter
-            .finalize()
-            .expect("Should not fail");
+        count += decrypter.finalize().expect("Should not fail");
 
         let plain_message = std::str::from_utf8(decrypter.get_message()).expect("Should not fail");
 
@@ -666,7 +717,6 @@ mod tests {
         );
     }
 
-    
     #[test]
     fn test_chunked_message_encryption() {
         let message = b"Encrypt this very long message in chunks and decrypt it";
@@ -676,8 +726,7 @@ mod tests {
         let mut chunk = [0u8; 5];
         let mut buf = vec![0u8; buff_len];
 
-        let mut encrypter =
-        DracoonCrypto::get_encrypter(&mut buf).expect("Should not fail");
+        let mut encrypter = DracoonCrypto::get_encrypter(&mut buf).expect("Should not fail");
 
         let mut cursor = std::io::Cursor::new(&message);
 
@@ -687,21 +736,18 @@ mod tests {
             count += encrypter.update(&chunk).expect("Should not fail");
         }
 
-        count += encrypter
-            .finalize()
-            .expect("Should not fail");
+        count += encrypter.finalize().expect("Should not fail");
 
         assert_eq!(count, message.len());
 
         let enc_message = encrypter.get_message().to_vec();
         let plain_file_key = encrypter.get_plain_file_key();
-        let plain_message = DracoonCrypto::decrypt(enc_message, plain_file_key).expect("Should not fail");
+        let plain_message =
+            DracoonCrypto::decrypt(enc_message, plain_file_key).expect("Should not fail");
 
-        assert_eq!(plain_message, b"Encrypt this very long message in chunks and decrypt it");
-
-
+        assert_eq!(
+            plain_message,
+            b"Encrypt this very long message in chunks and decrypt it"
+        );
     }
-
-
-
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -253,7 +253,7 @@ pub enum DracoonCryptoError {
     RsaOperationFailed,
     RsaImportFailed,
     ByteParseError,
-    CrypterOperationFailed,
+    CrypterOperationFailed(String),
     InvalidKeypairVersion,
     BadData,
     InvalidFileKeyFormat(String),

--- a/src/models.rs
+++ b/src/models.rs
@@ -2,7 +2,7 @@
 use openssl::base64;
 use openssl::error::ErrorStack;
 use openssl::rand::rand_bytes;
-use openssl::symm::{Cipher, Crypter as OpenSSLCrypter, Mode};
+use openssl::symm::{Mode};
 use serde::{Serialize, Deserialize};
 use std::str::Utf8Error;
 
@@ -327,98 +327,41 @@ pub trait DracoonRSACrypto {
 /// Trait representing necessary functions for symmetric encryption
 /// - encrypt on the fly
 /// - return an encrypter for chunked encryption
-pub trait Encrypt {
+pub trait Encrypt<C> {
     fn encrypt(data: Vec<u8>) -> Result<EncryptionResult, DracoonCryptoError>;
 
-    fn get_encrypter(buffer: &mut Vec<u8>) -> Result<Crypter, DracoonCryptoError>;
+    fn get_encrypter(buffer: &mut Vec<u8>) -> Result<Crypter<C>, DracoonCryptoError>;
 }
 
 /// Trait representing necessary functions for symmetric decryption
 /// - decrypt on the fly
 /// - return a decrypter for chunked decryption
-pub trait Decrypt {
+pub trait Decrypt<C> {
     fn decrypt(data: Vec<u8>, plain_file_key: PlainFileKey) -> Result<Vec<u8>, DracoonCryptoError>;
 
-    fn get_decrypter(plain_file_key: PlainFileKey, buffer: &mut Vec<u8>) -> Result<Crypter, DracoonCryptoError>;
+    fn get_decrypter(plain_file_key: PlainFileKey, buffer: &mut Vec<u8>) -> Result<Crypter<C>, DracoonCryptoError>;
 }
 
 /// Allows chunked en- and decryption.
 /// Holds a reference to a buffer to store the mssage, processed bytes as count and 
 /// the used plain file key and mode.
-pub struct Crypter <'b> {
+pub struct Crypter <'b, C> {
     // needs to be generic in future release
-    crypter: OpenSSLCrypter,
-    buffer: &'b mut Vec<u8>,
-    count: usize,
-    plain_file_key: PlainFileKey,
-    mode: Mode
+    pub crypter: C,
+    pub buffer: &'b mut Vec<u8>,
+    pub count: usize,
+    pub plain_file_key: PlainFileKey,
+    pub mode: Mode
 }
 
-impl <'b> Crypter<'b> {
-    pub fn try_new_for_decryption(plain_file_key: PlainFileKey, buffer: &'b mut Vec<u8>) -> Result<Self, DracoonCryptoError> {
-        let cipher = Cipher::aes_256_gcm();
-        let key = base64::decode_block(&plain_file_key.key)?;
-        let iv = base64::decode_block(&plain_file_key.iv)?;
-        let tag = plain_file_key.tag.clone().ok_or(DracoonCryptoError::CrypterOperationFailed)?;
-        let tag = base64::decode_block(&tag)?;
-
-        let mut crypter = OpenSSLCrypter::new(cipher, Mode::Decrypt, &key, Some(&iv))?;
-
-        crypter.aad_update(b"")?;
-        crypter.set_tag(&tag)?;
-
-        Ok(Crypter { crypter, buffer, count: 0, plain_file_key, mode: Mode::Decrypt })
-    }
-
-    pub fn try_new_for_encryption(buffer: &'b mut Vec<u8>) -> Result<Self, DracoonCryptoError> {
-        let cipher = Cipher::aes_256_gcm();
-        let plain_file_key = PlainFileKey::try_new_for_encryption()?;
-        let key = base64::decode_block(&plain_file_key.key)?;
-        let iv = base64::decode_block(&plain_file_key.iv)?;
-
-        let mut crypter = OpenSSLCrypter::new(cipher, Mode::Encrypt, &key, Some(&iv))?;
-        crypter.aad_update(b"")?;
-
-        Ok(Crypter { crypter, buffer, count: 0, plain_file_key, mode: Mode::Encrypt })
-    }
-
-    pub fn update(&mut self, data: &[u8]) -> Result<usize, DracoonCryptoError> {
-
-        match self.crypter.update(data, &mut self.buffer[self.count..]) {
-            Ok(count) => {self.count += count; Ok(count)},
-            Err(_) => Err(DracoonCryptoError::CrypterOperationFailed)
-        }
-
-    }
-
-    pub fn set_tag(&mut self, tag: &[u8]) -> Result<(), DracoonCryptoError> {
-        Ok(self.crypter.set_tag(tag)?)
-    }
-
-    pub fn finalize(&mut self) -> Result<usize, DracoonCryptoError> {
-
-        let count = self.crypter.finalize(&mut self.buffer[self.count..])?;
-
-        if let Mode::Encrypt = self.mode {
-            let mut buf = [0u8; 16];
-            self.crypter.get_tag(&mut buf)?; 
-            let tag = base64::encode_block(&buf);
-            self.plain_file_key.tag = Some(tag);
-
-        };
-
-       Ok(count)
-    }
-
-    pub fn get_message(&mut self) -> &Vec<u8> {
-
-        self.buffer.truncate(self.count);
-
-        &self.buffer
-    }
-
-    pub fn get_plain_file_key(self) -> PlainFileKey {
-        self.plain_file_key
-    }
+pub trait ChunkedEncryption<'b, C> {
+    fn try_new_for_decryption(plain_file_key: PlainFileKey, buffer: &'b mut Vec<u8>) -> Result<Crypter<C>, DracoonCryptoError>;
+    fn try_new_for_encryption(buffer: &'b mut Vec<u8>) -> Result<Crypter<C>, DracoonCryptoError>;
+    fn update(&mut self, data: &[u8]) -> Result<usize, DracoonCryptoError>;
+    fn set_tag(&mut self, tag: &[u8]) -> Result<(), DracoonCryptoError>;
+    fn finalize(&mut self) -> Result<usize, DracoonCryptoError>;
+    fn get_message(&mut self) -> &Vec<u8>;
+    fn get_plain_file_key(self) -> PlainFileKey;
 
 }
+

--- a/src/models.rs
+++ b/src/models.rs
@@ -28,7 +28,7 @@ pub enum PlainFileKeyVersion {
 
 /// Represents the user keypair version 
 /// Standard is 4096 bit (2048 bit for compatibility only)
-#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub enum UserKeyPairVersion {
     #[serde(rename = "A")]
     RSA2048,


### PR DESCRIPTION
- make lib generic so that other libraries next to `openssl` can be used (e.g. `ring`)
- refactor chunked encryption (new traits `Decrypter` and `Encrypter`
- accept slices and vecs vor byte input
- extended error messages (custom errors) and added minor logging
- add pipeline to all branches
- add linting to pipeline (`clippy`)
- update readme