### PR TITLE
feat(mcp): add optional JSON schema support and bump version to 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dco3_crypto"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 authors = ["Octavio Simone"]
 repository = "https://github.com/unbekanntes-pferd/dco3-crypto"
@@ -13,12 +13,14 @@ description = "Symmetric and asymmetric encryption for DRACOON in Rust."
 [features]
 default = ["vendored-openssl"]
 vendored-openssl = ["openssl/vendored"]
+mcp = ["dep:schemars"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tracing = "0.1.44"
+tracing = "0.1"
 serde_json = "1"
 serde = { version = "1", features = ["serde_derive"] }
+schemars = { version = "1", optional = true }
 openssl = "0.10.76"
-yasna = "0.5"
+yasna = "0.6"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Using the crate currently binds to the latest openssl version and is compiled in
 See [crates.io](https://crates.io/crates/dco3_crypto)
 TL;DR Add the following line to your Cargo.toml file (dependencies):
 ```toml
-dco3_crypto = "0.9.0"
+dco3_crypto = "0.10.0"
 ```
 
 ## Documentation

--- a/src/models.rs
+++ b/src/models.rs
@@ -9,6 +9,7 @@ use std::str::Utf8Error;
 ///
 /// The value encodes the required RSA key pair version together with AES-256-GCM as the file
 /// content cipher.
+#[cfg_attr(feature = "mcp", derive(schemars::JsonSchema))]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum FileKeyVersion {
     #[serde(rename = "A")]
@@ -20,6 +21,7 @@ pub enum FileKeyVersion {
 /// Version of the plain file key.
 ///
 /// DRACOON currently uses AES-256-GCM only.
+#[cfg_attr(feature = "mcp", derive(schemars::JsonSchema))]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum PlainFileKeyVersion {
     #[serde(rename = "AES-256-GCM")]
@@ -29,6 +31,7 @@ pub enum PlainFileKeyVersion {
 /// Version of the user key pair.
 ///
 /// RSA-4096 is the default. RSA-2048 is kept for compatibility.
+#[cfg_attr(feature = "mcp", derive(schemars::JsonSchema))]
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub enum UserKeyPairVersion {
     #[serde(rename = "A")]
@@ -40,6 +43,7 @@ pub enum UserKeyPairVersion {
 /// Wrapped file key used to decrypt AES-256-GCM file content.
 ///
 /// `key`, `iv`, and `tag` are base64-encoded. `key` is wrapped with the receiver's public key.
+#[cfg_attr(feature = "mcp", derive(schemars::JsonSchema))]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct FileKey {
     pub key: String,
@@ -51,6 +55,7 @@ pub struct FileKey {
 /// Plain file key used for AES-256-GCM file content encryption and decryption.
 ///
 /// `key`, `iv`, and `tag` are base64-encoded.
+#[cfg_attr(feature = "mcp", derive(schemars::JsonSchema))]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct PlainFileKey {
     pub key: String,
@@ -60,6 +65,7 @@ pub struct PlainFileKey {
 }
 
 /// Public key container used to wrap file keys.
+#[cfg_attr(feature = "mcp", derive(schemars::JsonSchema))]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct PublicKeyContainer {
@@ -71,6 +77,7 @@ pub struct PublicKeyContainer {
 }
 
 /// Private key container used to unwrap file keys.
+#[cfg_attr(feature = "mcp", derive(schemars::JsonSchema))]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct PrivateKeyContainer {
@@ -84,6 +91,7 @@ pub struct PrivateKeyContainer {
 /// Encrypted user key pair container.
 ///
 /// The private key is protected with a passphrase.
+#[cfg_attr(feature = "mcp", derive(schemars::JsonSchema))]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct UserKeyPairContainer {
@@ -94,6 +102,7 @@ pub struct UserKeyPairContainer {
 /// Plain user key pair container.
 ///
 /// The private key is unencrypted and ready for cryptographic operations.
+#[cfg_attr(feature = "mcp", derive(schemars::JsonSchema))]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct PlainUserKeyPairContainer {
@@ -233,6 +242,7 @@ impl PlainFileKey {
 }
 
 /// State of rescue keys in a room.
+#[cfg_attr(feature = "mcp", derive(schemars::JsonSchema))]
 #[derive(Serialize, Debug, Clone, PartialEq)]
 pub enum KeyState {
     #[serde(rename = "none")]
@@ -244,6 +254,7 @@ pub enum KeyState {
 }
 
 /// Rescue-key state for a room.
+#[cfg_attr(feature = "mcp", derive(schemars::JsonSchema))]
 #[derive(Serialize, Debug, Clone, PartialEq)]
 pub struct EncryptionInfo {
     user_key_state: KeyState,

--- a/src/tests/mcp.rs
+++ b/src/tests/mcp.rs
@@ -1,0 +1,51 @@
+use schemars::schema_for;
+use serde_json::Value;
+
+fn schema_json<T: schemars::JsonSchema>() -> Value {
+    serde_json::to_value(schema_for!(T)).unwrap()
+}
+
+#[test]
+fn public_key_container_schema_uses_serde_field_names() {
+    let schema = schema_json::<crate::PublicKeyContainer>();
+    let properties = schema["properties"].as_object().unwrap();
+    let required = schema["required"].as_array().unwrap();
+
+    assert!(properties.contains_key("publicKey"));
+    assert!(properties.contains_key("createdAt"));
+    assert!(properties.contains_key("expireAt"));
+    assert!(properties.contains_key("createdBy"));
+    assert!(required.contains(&Value::String("version".to_string())));
+    assert!(required.contains(&Value::String("publicKey".to_string())));
+    assert!(!required.contains(&Value::String("createdAt".to_string())));
+}
+
+#[test]
+fn user_key_pair_container_schema_contains_nested_defs() {
+    let schema = schema_json::<crate::UserKeyPairContainer>();
+    let defs = schema["$defs"].as_object().unwrap();
+
+    assert!(defs.contains_key("PrivateKeyContainer"));
+    assert!(defs.contains_key("PublicKeyContainer"));
+    assert!(schema["properties"]
+        .as_object()
+        .unwrap()
+        .contains_key("privateKeyContainer"));
+    assert!(schema["properties"]
+        .as_object()
+        .unwrap()
+        .contains_key("publicKeyContainer"));
+}
+
+#[test]
+fn plain_file_key_schema_contains_optional_tag() {
+    let schema = schema_json::<crate::PlainFileKey>();
+    let properties = schema["properties"].as_object().unwrap();
+    let required = schema["required"].as_array().unwrap();
+
+    assert!(properties.contains_key("key"));
+    assert!(properties.contains_key("iv"));
+    assert!(properties.contains_key("version"));
+    assert!(properties.contains_key("tag"));
+    assert!(!required.contains(&Value::String("tag".to_string())));
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[cfg(feature = "mcp")]
+mod mcp;
+
 use openssl::base64;
 use openssl::pkey::{PKey, Private, Public};
 use serde::de::DeserializeOwned;


### PR DESCRIPTION
- add optional JSON schema support (for MCP server implementation)